### PR TITLE
Remove Edelwood from minecraft:logs tag.

### DIFF
--- a/src/main/resources/data/minecraft/tags/items/logs.json
+++ b/src/main/resources/data/minecraft/tags/items/logs.json
@@ -1,8 +1,7 @@
 {
   "replace": false,
   "values": [
-    "forbidden_arcanus:edelwood_log",
     "#forbidden_arcanus:cherrywood_logs",
-	"#forbidden_arcanus:mysterywood_logs"
+    "#forbidden_arcanus:mysterywood_logs"
   ]
 }


### PR DESCRIPTION
Prevents Edelwood from becoming Charcoal, overwriting Dark Matter smelting recipe. 

(Sorry, my mistake for including it in the first place).