### PR TITLE
Make edelwood bucket more compabitle with other mods

### DIFF
--- a/src/main/java/com/stal111/forbidden_arcanus/block/ArcaneCrystalObeliskBlock.java
+++ b/src/main/java/com/stal111/forbidden_arcanus/block/ArcaneCrystalObeliskBlock.java
@@ -61,17 +61,6 @@ public class ArcaneCrystalObeliskBlock extends CutoutBlock implements IWaterLogg
         this.setDefaultState(this.getStateContainer().getBaseState().with(PART, ArcaneCrystalObeliskPart.LOWER).with(WATERLOGGED, false));
     }
 
-    @Override
-    public VoxelShape getShape(BlockState state, IBlockReader world, BlockPos pos, ISelectionContext context) {
-        ArcaneCrystalObeliskPart part = state.get(PART);
-        if (part == ArcaneCrystalObeliskPart.LOWER) {
-            return LOWER_SHAPE;
-        } else if (part == ArcaneCrystalObeliskPart.MIDDLE) {
-            return  MIDDLE_SHAPE;
-        } else {
-            return UPPER_SHAPE;
-        }
-
     @Nonnull
     @Override
     public VoxelShape getShape(BlockState state, @Nonnull IBlockReader world, @Nonnull BlockPos pos, @Nonnull ISelectionContext context) {


### PR DESCRIPTION
This pull request changes the edelwood bucket to also check for FLUID_HANDLER_CAPABILITY in addition to IBucketPickupHandler to make it more compatible with other mods. In addition to that, this pull request also allows milk to be picked up, which fixes issue #159.

Note: I had to remove some code ArcaneCrystalObeliskBlock to get rid of some compilation error. It looks like that code was leftover from refactoring in a previous commit.