### PR TITLE
Add missing lang entries for potted plants

### DIFF
--- a/src/main/resources/assets/forbidden_arcanus/lang/en_us.json
+++ b/src/main/resources/assets/forbidden_arcanus/lang/en_us.json
@@ -164,6 +164,10 @@
     "block.forbidden_arcanus.fungyss": "Fungyss",
     "block.forbidden_arcanus.fungyss_block": "Fungyss Block",
 
+    "block.forbidden_arcanus.potted_cherrywood_sapling": "Potted Cherry Sapling",
+    "block.forbidden_arcanus.potted_mysterywood_sapling": "Potted Aurum Sapling",
+    "block.forbidden_arcanus.potted_yellow_orchid": "Potted Yellow Orchid",
+
     "____comment": "Items",
     "item.forbidden_arcanus.forbiddenmicon": "Forbiddenmicon",
     "item.forbidden_arcanus.stellarite_piece": "Stellarite Piece",


### PR DESCRIPTION
This PR adds localized names for the 3 flower pot blocks added by Forbidden & Arcanus. The use for these translations in vanilla is almost nonexistent, but mods can still get them using Block::getName (All vanilla blocks are translated even if they don't have a corresponding item)