### PR TITLE
Fix a Blacksmith Gavel dupe bug [1.19]

### DIFF
--- a/src/generated/resources/.cache/3a07a1f76a9dec468ee600bb6be1ff847c54362d
+++ b/src/generated/resources/.cache/3a07a1f76a9dec468ee600bb6be1ff847c54362d
@@ -1,6 +1,6 @@
-// 1.19.4	2023-03-26T13:22:35.1643841	Tags for minecraft:block mod id forbidden_arcanus
+// 1.19.4	2023-10-15T13:22:25.5412763	Tags for minecraft:block mod id forbidden_arcanus
 15ddb20eec4f474e9a7277aa0e68dd069b704173 data/forbidden_arcanus/tags/blocks/arcane_crystal_ores.json
-35133e95f1c8fdd7a1c21afcc231fc0bffefb9a8 data/forbidden_arcanus/tags/blocks/blacksmith_gavel_unaffected.json
+19b073a7559571c409a9e82de27bfabac67ee6ac data/forbidden_arcanus/tags/blocks/blacksmith_gavel_unaffected.json
 8c6e37a9a9345b42c82959b74579b25696da1e40 data/forbidden_arcanus/tags/blocks/cherrywood_logs.json
 7178fc65549c2cdfe3c0d34421efedf7c81a341f data/forbidden_arcanus/tags/blocks/darkstone_ore_replaceables.json
 0611649b247c64b861461321d4cc20337d569c68 data/forbidden_arcanus/tags/blocks/edelwood_logs.json

--- a/src/generated/resources/.cache/59eb3dbb5f86130e09b3c62d89b9525ee01cf52d
+++ b/src/generated/resources/.cache/59eb3dbb5f86130e09b3c62d89b9525ee01cf52d
@@ -1,4 +1,4 @@
-// 1.19.4	2023-05-29T13:19:31.772095	Loot Tables
+// 1.19.4	2023-10-15T13:22:25.5462744	Loot Tables
 05c266cf1efb292d3d3249030b1ffd363e53f6e3 data/forbidden_arcanus/loot_tables/blocks/arcane_chiseled_darkstone.json
 2632e8ea943baf43e1c62df24e5121e8b8f6586f data/forbidden_arcanus/loot_tables/blocks/arcane_chiseled_polished_darkstone.json
 dc3174bd0b22aa113f03331261ac0e1ce750cf1b data/forbidden_arcanus/loot_tables/blocks/arcane_crystal_block.json
@@ -160,6 +160,7 @@ c7518b115d075ec0193730dec280a56f38256cc7 data/forbidden_arcanus/loot_tables/bloc
 2968f020e08806b33d90278197052ffb8cd31fcd data/forbidden_arcanus/loot_tables/blocks/stripped_cherry_wood.json
 069c790221347ba826806fc38dfa99a1e3754a08 data/forbidden_arcanus/loot_tables/blocks/thin_cherry_log.json
 597b0d7ade0cf965191bf7b457b31e815fa5fbff data/forbidden_arcanus/loot_tables/blocks/tiled_polished_darkstone_bricks.json
+2b2a4bde1a1c86393b28fa3ff9b81ef1ddeed22d data/forbidden_arcanus/loot_tables/blocks/upwind.json
 1848fba4104ef073c4e9f59532fed3c41d29febd data/forbidden_arcanus/loot_tables/blocks/utrem_jar.json
 2b2a4bde1a1c86393b28fa3ff9b81ef1ddeed22d data/forbidden_arcanus/loot_tables/blocks/whirlwind.json
 a11c4c0cd589c2ce6a4a1e5955515b42c1ac27d1 data/forbidden_arcanus/loot_tables/blocks/xpetrified_ore.json

--- a/src/generated/resources/.cache/b98346939a4764201a184a9091e7a10a2f8eada8
+++ b/src/generated/resources/.cache/b98346939a4764201a184a9091e7a10a2f8eada8
@@ -1,4 +1,4 @@
-// 1.19.4	2023-03-26T13:22:35.1923063	Tags for minecraft:item mod id forbidden_arcanus
+// 1.19.4	2023-10-15T13:22:25.552447	Tags for minecraft:item mod id forbidden_arcanus
 15ddb20eec4f474e9a7277aa0e68dd069b704173 data/forbidden_arcanus/tags/items/arcane_crystal_ores.json
 0eeb55318c55e51648d2e850da000a6e461d6815 data/forbidden_arcanus/tags/items/blacksmith_gavel.json
 15934456b6a5c4baa26b521dac8e9ec371c2b006 data/forbidden_arcanus/tags/items/black_hole_unaffected.json
@@ -35,6 +35,7 @@ b128c22b1f0aef1502fa919bc8d063604b299c75 data/forge/tags/items/storage_blocks/de
 ce2508892f23ecc4a019953c279d5bba6c908716 data/minecraft/tags/items/doors.json
 2573ed5fa40458e79d5a51f0321c3cedd6bf5dd3 data/minecraft/tags/items/leaves.json
 21ceee370fb7ad0bb83b405e7f92b1ed504c29cf data/minecraft/tags/items/logs.json
+69f86cd5de0f713fdbc24827fd81b631cbc51404 data/minecraft/tags/items/pickaxes.json
 369674d5826e2cb2f27e403624001d2f9202639a data/minecraft/tags/items/planks.json
 2ae2823ba754386a4370da044ed59d77c03c6b32 data/minecraft/tags/items/saplings.json
 17aacb83834d35cca378c25ef6c6a5f0530932ac data/minecraft/tags/items/signs.json

--- a/src/generated/resources/data/forbidden_arcanus/loot_tables/blocks/upwind.json
+++ b/src/generated/resources/data/forbidden_arcanus/loot_tables/blocks/upwind.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:air"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/generated/resources/data/forbidden_arcanus/tags/blocks/blacksmith_gavel_unaffected.json
+++ b/src/generated/resources/data/forbidden_arcanus/tags/blocks/blacksmith_gavel_unaffected.json
@@ -1,3 +1,5 @@
 {
-  "values": []
+  "values": [
+    "minecraft:ancient_debris"
+  ]
 }

--- a/src/main/java/com/stal111/forbidden_arcanus/data/client/ModBlockStateProvider.java
+++ b/src/main/java/com/stal111/forbidden_arcanus/data/client/ModBlockStateProvider.java
@@ -40,6 +40,7 @@ public class ModBlockStateProvider extends ValhelsiaBlockStateProvider {
     @Override
     protected void registerStatesAndModels() {
         Arrays.asList(
+                ModBlocks.UPWIND,
                 ModBlocks.OBSIDIAN_SKULL,
                 ModBlocks.OBSIDIAN_WALL_SKULL,
                 ModBlocks.ETERNAL_OBSIDIAN_SKULL,

--- a/src/main/java/com/stal111/forbidden_arcanus/data/server/tags/ModBlockTagsProvider.java
+++ b/src/main/java/com/stal111/forbidden_arcanus/data/server/tags/ModBlockTagsProvider.java
@@ -4,6 +4,7 @@ import com.stal111.forbidden_arcanus.core.init.ModBlocks;
 import com.stal111.forbidden_arcanus.util.ModTags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.common.Tags;
 import net.valhelsia.valhelsia_core.core.data.DataProviderInfo;
 import net.valhelsia.valhelsia_core.core.data.tags.ValhelsiaBlockTagsProvider;
@@ -51,7 +52,7 @@ public class ModBlockTagsProvider extends ValhelsiaBlockTagsProvider {
         this.tag(BlockTags.TRAPDOORS).add(ModBlocks.DEORUM_TRAPDOOR.get());
         this.tag(BlockTags.CLIMBABLE).add(ModBlocks.EDELWOOD_LADDER.get(), ModBlocks.CHERRY_FLOWER_VINES.get(), ModBlocks.CHERRY_FLOWER_VINES_PLANT.get());
         this.tag(BlockTags.FLOWER_POTS).add(ModBlocks.POTTED_FUNGYSS.get(), ModBlocks.POTTED_CHERRY_SAPLING.get(), ModBlocks.POTTED_AURUM_SAPLING.get(), ModBlocks.POTTED_GROWING_EDELWOOD.get(), ModBlocks.POTTED_YELLOW_ORCHID.get());
-        this.tag(ModTags.Blocks.BLACKSMITH_GAVEL_UNAFFECTED);
+        this.tag(ModTags.Blocks.BLACKSMITH_GAVEL_UNAFFECTED).add(Blocks.ANCIENT_DEBRIS);
         this.tag(ModTags.Blocks.MAGICAL_FARMLAND_BLACKLISTED);
         this.tag(ModTags.Blocks.RUNIC_STONES).add(ModBlocks.RUNIC_STONE.get(), ModBlocks.RUNIC_DEEPSLATE.get(), ModBlocks.RUNIC_DARKSTONE.get());
         this.tag(ModTags.Blocks.RUNE_BLOCKS).add(ModBlocks.RUNE_BLOCK.get(), ModBlocks.DARK_RUNE_BLOCK.get());

--- a/src/main/resources/data/forge/tags/blocks/blacksmith_gavel_unaffected.json
+++ b/src/main/resources/data/forge/tags/blocks/blacksmith_gavel_unaffected.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "minecraft:ancient_debris"
-  ]
-}

--- a/src/main/resources/data/forge/tags/blocks/blacksmith_gavel_unaffected.json
+++ b/src/main/resources/data/forge/tags/blocks/blacksmith_gavel_unaffected.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:ancient_debris"
+  ]
+}


### PR DESCRIPTION
this is a simple fix on 1.19 for the Blacksmith Gavel Ancient Debris dupe bug. 