### PR TITLE
Fix Corrupted Pixie recipe

### DIFF
--- a/src/main/resources/data/forbidden_arcanus/recipes/corrupted_pixie.json
+++ b/src/main/resources/data/forbidden_arcanus/recipes/corrupted_pixie.json
@@ -20,7 +20,7 @@
         },
          "D":
         {
-            "item": "forbidden_arcanus:dark_soul"
+            "item": "forbidden_arcanus:corrupt_soul"
         }
         
     },


### PR DESCRIPTION
Fixed errored recipe for Corrupted Pixie.

```
[23Feb2024 13:22:19.187] [Render thread/ERROR] [net.minecraft.world.item.crafting.RecipeManager/]: Parsing error loading recipe forbidden_arcanus:corrupted_pixie
com.google.gson.JsonSyntaxException: Unknown item 'forbidden_arcanus:dark_soul'
```

Caused by: fa1a0426c2a270da85927879c8ca27bddc121dd2