### PR TITLE
Hephaestus Forge fix for removing items

### DIFF
--- a/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/forge/ritual/Ritual.java
+++ b/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/forge/ritual/Ritual.java
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.Block;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
 
 /**
  * Ritual <br>
@@ -56,7 +57,7 @@ public class Ritual {
         return this.checkIngredients(inputs, blockEntity);
     }
 
-    public boolean checkIngredients(List<ItemStack> list, HephaestusForgeBlockEntity blockEntity) {
+    public boolean checkIngredients(Collection<ItemStack> list, HephaestusForgeBlockEntity blockEntity) {
         List<ItemStack> ingredients = new ArrayList<>(list);
 
         for (Ingredient ingredient : this.getInputs()) {

--- a/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/forge/ritual/RitualManager.java
+++ b/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/forge/ritual/RitualManager.java
@@ -112,19 +112,13 @@ public class RitualManager implements NeedsStoring {
             this.lightningCounter++;
 
             if (this.lightningCounter == 300) {
-                List<ItemStack> list = new ArrayList<>();
-
-                this.forEachPedestal(level, PedestalBlockEntity::hasStack, pedestalBlockEntity -> list.add(pedestalBlockEntity.getStack()));
-
-                if (!this.getActiveRitual().checkIngredients(list, this.blockEntity)) {
-                    this.failRitual(level);
-
-                    NetworkHandler.sendToTrackingChunk(level.getChunkAt(pos), new UpdateForgeRitualPacket(pos, this.activeRitual));
-                    return;
-                }
+                if (checkActiveRitualIngredients(level, pos)) return;
 
                 this.lightningCounter = 0;
             }
+        } else {
+            // Check if ritual is invalidated
+            if (checkActiveRitualIngredients(level, pos)) return;
         }
 
         this.forEachPedestal(level, PedestalBlockEntity::hasStack, pedestalBlockEntity -> {
@@ -169,6 +163,20 @@ public class RitualManager implements NeedsStoring {
         }
 
         NetworkHandler.sendToTrackingChunk(level.getChunkAt(pos), new UpdateForgeRitualPacket(pos, this.activeRitual));
+    }
+
+    private boolean checkActiveRitualIngredients(ServerLevel level, BlockPos pos) {
+        List<ItemStack> items = new ArrayList<>();
+
+        this.forEachPedestal(level, PedestalBlockEntity::hasStack, pedestalBlockEntity -> items.add(pedestalBlockEntity.getStack()));
+
+        if (!this.getActiveRitual().checkIngredients(items, this.blockEntity)) {
+            failRitual(level);
+            NetworkHandler.sendToTrackingChunk(level.getChunkAt(pos), new UpdateForgeRitualPacket(pos, this.activeRitual));
+
+            return true;
+        }
+        return false;
     }
 
     public void finishRitual(ServerLevel level) {


### PR DESCRIPTION
When an item gets removed from the pedestals, while the Forge is crafting it now fails the ritual, fixing an exploit for free crafts.
This was already fixed for later versions, but since I need this in 1.19.2, here is the "backport" of the fix.