### PR TITLE
[Issue][516] - Implement Nameable for ClibanoFrameBlockEntity.

### DIFF
--- a/neoforge/src/generated/resources/assets/forbidden_arcanus/lang/en_us.json
+++ b/neoforge/src/generated/resources/assets/forbidden_arcanus/lang/en_us.json
@@ -29,6 +29,7 @@
   "block.forbidden_arcanus.carved_edelwood_log": "Carved Edelwood Log",
   "block.forbidden_arcanus.chiseled_arcane_polished_darkstone": "Chiseled Arcane Polished Darkstone",
   "block.forbidden_arcanus.chiseled_polished_darkstone": "Chiseled Polished Darkstone",
+  "block.forbidden_arcanus.clibano": "Clibano",
   "block.forbidden_arcanus.clibano_core": "Clibano Core",
   "block.forbidden_arcanus.corrupted_arcane_crystal_block": "Corrupted Arcane Crystal Block",
   "block.forbidden_arcanus.corrupted_arcane_crystal_obelisk": "Corrupted Arcane Crystal Obelisk",

--- a/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/clibano/ClibanoFrameBlockEntity.java
+++ b/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/clibano/ClibanoFrameBlockEntity.java
@@ -5,6 +5,8 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.stal111.forbidden_arcanus.core.init.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.Nameable;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
  * @author stal111
  * @since 2022-05-22
  */
-public class ClibanoFrameBlockEntity extends BlockEntity {
+public class ClibanoFrameBlockEntity extends BlockEntity implements Nameable {
 
     private @Nullable Direction mainDirection;
     private @Nullable FrameData frameData;
@@ -45,6 +47,25 @@ public class ClibanoFrameBlockEntity extends BlockEntity {
 
     public void setMainDirection(@Nullable Direction mainDirection) {
         this.mainDirection = mainDirection;
+    }
+
+    @Override
+    public Component getName() {
+        return Component.translatable("block.forbidden_arcanus.clibano");
+    }
+
+    @Override
+    public boolean hasCustomName() {
+        return this.frameData != null;
+    }
+
+    @Nullable
+    @Override
+    public Component getCustomName() {
+        if (this.frameData != null) {
+            return Component.translatable("block.forbidden_arcanus.clibano");
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Fix for issue - [516](https://github.com/stal111/Forbidden-Arcanus/issues/516)
Added Nameable interface to ClibanoFrameBlockEntity, providing name and custom name methods. Also updated en_us.json to include a translation for 'block.forbidden_arcanus.clibano'.

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/88a13b04-eef0-4eaf-a03c-fb4f8989872a" />


