### PR TITLE
fix(metadata): load Forbidden Arcanus after Valhelsia Core

### DIFF
--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,7 +23,7 @@ side="BOTH"
 modId="valhelsia_core"
 type="required"
 versionRange="[1.1.4,)"
-ordering="NONE"
+ordering="AFTER"
 side="BOTH"
 
 [[mixins]]


### PR DESCRIPTION
### Summary

This updates the NeoForge metadata so Forbidden Arcanus loads after Valhelsia Core.

### Why

I ran into a startup crash with Forbidden Arcanus 2.7.0-beta.2, Valhelsia Core 1.1.6, NeoForge 26.1.2.36-beta, and JEI 29.5.0.28.

The first failure was in Forbidden Arcanus during static initialization:

```text
Caused by: java.lang.NullPointerException: Cannot invoke
"net.valhelsia.valhelsia_core.ValhelsiaCore.createRegistry(...)"
because "net.valhelsia.valhelsia_core.ValhelsiaCore.INSTANCE" is null
```

JEI then failed afterward because it touched the already-failed Forbidden Arcanus class.

Since ValhelsiaCore.INSTANCE is populated when Valhelsia Core is constructed, setting the dependency ordering to AFTER prevents Forbidden Arcanus from initializing its registry helpers before Valhelsia Core is ready.

###Testing
I tested this locally by patching the built Forbidden Arcanus jar with the same metadata change. After that, Forbidden Arcanus loaded successfully, JEI started normally, and I was able to create and load a new world.