### PR TITLE
Quantum Injector & Essence Jar Fixes

### DIFF
--- a/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/EssenceUtremJarBlock.java
+++ b/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/EssenceUtremJarBlock.java
@@ -100,7 +100,7 @@ public class EssenceUtremJarBlock extends UtremJarBlock implements EntityBlock {
         if (level.isClientSide()) {
             return BaseEntityBlock.createTickerHelper(blockEntityType, ModBlockEntities.ESSENCE_UTREM_JAR.get(), EssenceUtremJarBlockEntity::clientTick);
         }
-        return null;
+        return BaseEntityBlock.createTickerHelper(blockEntityType, ModBlockEntities.ESSENCE_UTREM_JAR.get(), EssenceUtremJarBlockEntity::serverTick);
     }
 
     @Override

--- a/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/EssenceUtremJarBlockEntity.java
+++ b/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/EssenceUtremJarBlockEntity.java
@@ -3,6 +3,7 @@ package com.stal111.forbidden_arcanus.common.block.entity;
 import com.stal111.forbidden_arcanus.common.block.properties.ModBlockStateProperties;
 import com.stal111.forbidden_arcanus.common.essence.storage.EssenceStorage;
 import com.stal111.forbidden_arcanus.core.init.ModBlockEntities;
+import com.stal111.forbidden_arcanus.core.init.ModBlocks;
 import com.stal111.forbidden_arcanus.core.init.ModDataComponents;
 import com.stal111.forbidden_arcanus.core.init.ModItems;
 import net.minecraft.core.BlockPos;
@@ -38,6 +39,14 @@ public class EssenceUtremJarBlockEntity extends BlockEntity implements BlockEnti
         blockEntity.rotateAnimation.startIfStopped(blockEntity.tickCount);
 
         blockEntity.tickCount++;
+    }
+
+    //Empty Jars should be empty
+    public static void serverTick(Level level, BlockPos pos, BlockState state, EssenceUtremJarBlockEntity blockEntity) {
+        if (blockEntity.getEssenceStorage().isEmpty()) {
+            level.setBlockAndUpdate(pos, ModBlocks.UTREM_JAR.get().withPropertiesOf(state));
+            blockEntity.setRemoved();
+        }
     }
 
     public ItemStack getAsItem() {

--- a/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/QuantumInjectorBlockEntity.java
+++ b/neoforge/src/main/java/com/stal111/forbidden_arcanus/common/block/entity/QuantumInjectorBlockEntity.java
@@ -121,7 +121,7 @@ public class QuantumInjectorBlockEntity extends BlockEntity implements BlockEnti
     }
 
     private void transferEssence(ServerLevel level, BlockPos pos) {
-        if (this.forgeBlockEntity == null || this.jarBlockEntity == null) {
+        if (this.forgeBlockEntity == null || this.jarBlockEntity == null || this.jarBlockEntity.getEssenceStorage().isEmpty()) {
             if (this.particlePath != null) {
                 this.particlePath = null;
 
@@ -135,8 +135,12 @@ public class QuantumInjectorBlockEntity extends BlockEntity implements BlockEnti
 
         this.particlePath = new ParticlePath(essenceType, this.jarBlockEntity.getBlockPos(), this.forgeBlockEntity.getBlockPos());
 
-        this.forgeBlockEntity.addEssence(essenceType, 5);
-        this.jarBlockEntity.addEssence(-5);
+        //Better amount handling & also update the jar when we drain it :3
+        int toTransfer = Math.min(5, this.jarBlockEntity.getEssenceStorage().amount());
+
+        this.forgeBlockEntity.addEssence(essenceType, toTransfer);
+        this.jarBlockEntity.addEssence(-toTransfer);
+        level.sendBlockUpdated(this.jarBlockEntity.getBlockPos(), this.jarBlockEntity.getBlockState(), this.jarBlockEntity.getBlockState(), 3);
 
         level.sendBlockUpdated(pos, this.getBlockState(), this.getBlockState(), 3);
     }


### PR DESCRIPTION
Quantum Injectors would constantly drain Essence Jars even if the jar has nothing left. This fixes that by making empty Essence Jars turn back into Utrem Jars.

Also tweaked the amount of essence transferred from a Jar to take the contained amount into consideration instead of always taking 5.

Also Also made the Quantum Injector update the target jar after draining it to make sure the client render & tooltip is updated.